### PR TITLE
Small fix for run_sc_sequencing

### DIFF
--- a/R/run_sc_sequencing.R
+++ b/R/run_sc_sequencing.R
@@ -33,8 +33,8 @@ run_sc_sequencing <- function(tumour_bams,
     checkArguments_scs(c(as.list(environment())))
     if(!is.list(purs))
     {
-        purs <- lapply(1:length(bams), function(x) purs)
-        ploidies <- lapply(1:length(bams), function(x) ploidies)
+        purs <- lapply(1:length(tumour_bams), function(x) purs)
+        ploidies <- lapply(1:length(tumour_bams), function(x) ploidies)
     }
     suppressPackageStartupMessages(require(parallel))
     suppressPackageStartupMessages(require(Rsamtools))


### PR DESCRIPTION
Hi @galder-max,

Here is a small fix for the `run_sc_sequencing` function where the `bams` variable needs to be defined in the working environment, before running the function. Instead, it uses the provided `tumour_bams` variable within the function.

Cheers,

Tom.