### PR TITLE
fix: resolve refitted purity parameter typo in getAS_CNA

### DIFF
--- a/R/getAS_CNA.R
+++ b/R/getAS_CNA.R
@@ -430,9 +430,9 @@ getAS_CNA <- function(res,
                          profile=if(any(grepl("refitted",names(res)))) res$allProfiles.refitted.auto[[x]] else res$allProfiles[[x]],
                          ac_counts_paths=list_ac_counts_paths[[x]],
                          phases=phases,
-                         purity=if(any(grepl("refitted",names(res)))) res$allSolutions.refitted.auto[[x]]$purity
+                         purity=if(any(grepl("refitted",names(res)))) res$allProfiles.refitted.auto[[x]]$purity
                                 else res$allSolutions[[x]]$purity,
-                         ploidy=if(any(grepl("refitted",names(res)))) res$allSolutions.refitted.auto[[x]]$ploidy
+                         ploidy=if(any(grepl("refitted",names(res)))) res$allProfiles.refitted.auto[[x]]$ploidy
                                 else res$allSolutions[[x]]$ploidy,
                          purs=purs[[x]],
                          ploidies=ploidies[[x]],


### PR DESCRIPTION
### Summary of changes
- Fixed a parameter extraction issue in 'getAS_CNA.R' where 'res$allSolutions.refitted.auto' was queried instead of 'res$allProfiles.refitted.auto'.
- Resolves silent 'NULL' injection into downstream mathematical calculations and prevents crashes during allele-specific CNA derivation.